### PR TITLE
Create `__version__` attribute

### DIFF
--- a/matplotlib_inline/__init__.py
+++ b/matplotlib_inline/__init__.py
@@ -1,1 +1,2 @@
 from . import backend_inline, config  # noqa
+__version__ = "0.1.3"  # noqa

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = matplotlib-inline
-version = 0.1.3
+version = attr: matplotlib_inline.__version__
 description = Inline Matplotlib backend for Jupyter
 author = IPython Development Team
 author_email = ipython-dev@scipy.org


### PR DESCRIPTION
So that users can check version when reporting errors with `from matplotlib_inline import __version__`

This could also be a nice time to switch to setuptools_scm if you want?