### PR TITLE
Do not trigger backend auto-resolution

### DIFF
--- a/matplotlib_inline/backend_inline.py
+++ b/matplotlib_inline/backend_inline.py
@@ -208,9 +208,9 @@ def configure_inline_support(shell, backend):
 
 def _enable_matplotlib_integration():
     """Enable extra IPython matplotlib integration when we are loaded as the matplotlib backend."""
-    from matplotlib import get_backend
+    from matplotlib import _get_backend_or_none
     ip = get_ipython()
-    backend = get_backend()
+    backend = _get_backend_or_none()
     if ip and backend == 'module://%s' % __name__:
         from IPython.core.pylabtools import activate_matplotlib
         try:


### PR DESCRIPTION
Current `matplotlib` will selected a backend if none is already selected when calling `get_backend`. It should not be used if you just want to know what the backend is.

See #25.