### PR TITLE
Add matplotlib.backend entry point

### DIFF
--- a/matplotlib_inline/__init__.py
+++ b/matplotlib_inline/__init__.py
@@ -1,2 +1,2 @@
 from . import backend_inline, config  # noqa
-__version__ = "0.1.6"  # noqa
+__version__ = "0.1.7.dev1"  # noqa

--- a/matplotlib_inline/backend_inline.py
+++ b/matplotlib_inline/backend_inline.py
@@ -176,7 +176,7 @@ def configure_inline_support(shell, backend):
     if cfg not in shell.configurables:
         shell.configurables.append(cfg)
 
-    if backend == 'module://matplotlib_inline.backend_inline':
+    if backend in ('inline', 'module://matplotlib_inline.backend_inline'):
         shell.events.register('post_execute', flush_figures)
 
         # Save rcParams that will be overwrittern

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">=3.8"
 
+[project.entry-points."matplotlib.backend"]
+inline = "matplotlib_inline.backend_inline"
+
 [project.urls]
 Homepage = "https://github.com/ipython/matplotlib-inline"
 


### PR DESCRIPTION
This adds an entry point to `pyproject.toml` for matplotlib-inline to register itself as a Matplotlib backend. It is part of the planned transition of backend mapping from IPython to Matplotlib (matplotlib/matplotlib#27663 and ipython/ipython#14311).

I have bumped the package `__version__` as it will be used by Matplotlib to determine if a backward-compatible shim is required for this backend.