### PR TITLE
Use short matplotlib backend name

### DIFF
--- a/matplotlib_inline/backend_inline.py
+++ b/matplotlib_inline/backend_inline.py
@@ -211,7 +211,7 @@ def _enable_matplotlib_integration():
     from matplotlib import get_backend
     ip = get_ipython()
     backend = get_backend()
-    if ip and backend == 'module://%s' % __name__:
+    if ip and backend in ('inline', 'module://matplotlib_inline.backend_inline'):
         from IPython.core.pylabtools import activate_matplotlib
         try:
             activate_matplotlib(backend)


### PR DESCRIPTION
Support Matplotlib returning either `"inline"` or `"module://matplotlib_inline.backend_inline"` for the name of the backend. Note the line changed is consistent with
https://github.com/ipython/matplotlib-inline/blob/c5887eab4bf4b594be8f7cfd738bfff4d6fede88/matplotlib_inline/backend_inline.py#L179

In future, any use of `%matplotlib inline` or `matplotlib.use("inline")` will return `"inline"` from `matplotlib.get_backend()`. For backward compatibility we also need to support `"module://matplotlib_inline.backend_inline"`. Also it will always be acceptable to use `matplotlib.use("module://matplotlib_inline.backend_inline")`, even though it is unnecessarily complicated and hence discouraged, and Matplotlib may or may not convert that to `"inline"` in future.