### PR TITLE
Add OSI approved license classifier to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Framework :: Jupyter",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Add OSI approved license classifier to `pyproject.toml`. Fixes #53.

As successfully used in [contourpy](https://github.com/contourpy/contourpy/blob/d697df3ea9e952e81d3e6c3da5fd9934f3827f40/pyproject.toml#L17) and [ipympl](https://github.com/matplotlib/ipympl/blob/0f19f0a2b6b3df37787368bdb3669663d833d7ac/pyproject.toml#L34).