### PR TITLE
Specify BSD license and add license files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install package with test dependencies
-      run: pip install .[test]
+      # matplotlib is not a dependency but tests need it
+      run: |
+        pip install .[test]
+        pip install matplotlib
 
     - name: Test installation without nbdime
       run: pytest -v

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
         include:
           #- os: macos-latest
           #  python-version: "3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ keywords = [
     "matplotlib",
     "python",
 ]
-license = {file = "LICENSE"}
+license = "BSD-3.0"
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.9"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ keywords = [
     "matplotlib",
     "python",
 ]
-license = "BSD-3.0"
+license = "BSD-3-Clause"
 license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Fixes license specifiers according to https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

This allows automatic license inspection tools like pip-licenses to correctly categorize this package.

Also attempts to fix the test pipeline.

Closes #55 #58 #63 